### PR TITLE
Remove index.html from older newer links for pagination

### DIFF
--- a/jekyll/_layouts/category_index.html
+++ b/jekyll/_layouts/category_index.html
@@ -16,12 +16,12 @@ layout: default
         <ul class="pager">
             {% if paginator.previous_page %}
             <li class="previous">
-                <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
+                <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' | replace: 'index.html', '' }}">&larr; Newer Posts</a>
             </li>
             {% endif %}
             {% if paginator.next_page %}
             <li class="next">
-                <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
+                <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' | replace: 'index.html', '' }}">Older Posts &rarr;</a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
This will basically keep the URLs for pagination consistent with the rest of the site.

The older, newer links for pagination will go from `/category/EN/2/index.html` to `/category/EN/2/`