### PR TITLE
Remove title property in _config.yml in pagination section (Closes #18)

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -43,7 +43,6 @@ pagination:
   enabled: true
   per_page: 10
   permalink: '/page/:num/'
-  title: ' - page :num'
   limit: 0
   sort_field: 'date'
   sort_reverse: true


### PR DESCRIPTION
This will fix the title for paginated categories where title was " - page 2". For issue #18