### PR TITLE
Fix posts page / RSS (Solves #17)

### DIFF
--- a/jekyll/_includes/post_page_display.html
+++ b/jekyll/_includes/post_page_display.html
@@ -1,0 +1,12 @@
+<div class="panel panel-primary">
+	<div class="panel-heading" style="background-color: #4040bf;">
+            <p style="margin-top: 0; margin-bottom: 0;"><a style="font-size: 22px; color: white;" href="{{ page.href }}">{{ page.title }}</a></p>
+    </div>
+
+    <div class="panel-body" style="background-color: #d9d9d9;">
+
+            {% for tag in page.tags %}
+                <b><a id="tag" style="margin-top: 0; margin-bottom: 0; font-size: 15px;" class="tag" href="{{ site.url }}/{{ site.tag_page_dir }}/{{ tag | slugify: 'pretty' }}/">{{ tag }}</a></b>
+            {% endfor %}
+    </div>
+</div>

--- a/jekyll/_layouts/post.html
+++ b/jekyll/_layouts/post.html
@@ -3,6 +3,6 @@ layout: default
 ---
 <div class="container">
     <div class="text-center">
-        {% include post_display.html %}
+        {% include post_page_display.html %}
     </div>
 </div>


### PR DESCRIPTION
The single post pages that the RSS links to is needed to access data line {{ page,tags }} instead of how in other parts of the site where it is accessed as {{ post.tags }}.  So I had to make a second _include file called post_page_display.html and make that change there so it doesn't break the tag pages.