### PR TITLE
NL/Dutch resources

### DIFF
--- a/jekyll/_posts/NL/2017-11-08-depressie-vereniging.md
+++ b/jekyll/_posts/NL/2017-11-08-depressie-vereniging.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Depressie Vereniging"
-href: http://www.depressievereniging.nl/
+href: https://www.depressievereniging.nl/
 date: 2017-11-08 12:14:53 -0600
 tags: [depressie, Hulpverleners van Korrelatie, Nieuws]
 categories: NL

--- a/jekyll/_posts/NL/2017-11-12-ervaringswijzer.md
+++ b/jekyll/_posts/NL/2017-11-12-ervaringswijzer.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Ervaringswijzer"
+href: https://ervaringswijzer.nl/
+date: 2017-11-12 12:43:53 -0600
+tags: [zelfhulp, herstel, Nieuws]
+categories: NL
+---


### PR DESCRIPTION
- Corrects depressievereniging link to use HTTPS, because they don't redirect HTTP traffic to HTTPS (reported to them today).
- Adds Ervaringswijzer link, a site with News and resources aimed at people who are on their way to recovery in all kinds of psyches.