### PR TITLE
Remove {desc} from title attribute in search result elemnts

### DIFF
--- a/jekyll/_includes/footer.html
+++ b/jekyll/_includes/footer.html
@@ -42,7 +42,7 @@
       searchInput: document.getElementById('search-input'),
       resultsContainer: document.getElementById('results-container'),
       json: '{{ site.baseurl }}/search.json',
-      searchResultTemplate: '<li><a href="{url}" title="{desc}">{title}</a></li>',
+      searchResultTemplate: '<li><a href="{url}">{title}</a></li>',
       noResultsText: '<li class="no-results-text">No results found</li>',
       limit: 10,
       fuzzy: false,


### PR DESCRIPTION
Removes the `title="{desc}"` from the search results elements as mentioned by @sexybiggetje 