### PR TITLE
Fix tagging issues, remove jekyll-tagging, closes #73

### DIFF
--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -21,7 +21,7 @@ gem "jekyll", "~> 3.6.2"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-paginate-v2"
-  gem "jekyll-tagging", "~> 1.0", ">= 1.0.1"
+  # gem "jekyll-tagging", "~> 1.0", ">= 1.0.1"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/jekyll/Gemfile.lock
+++ b/jekyll/Gemfile.lock
@@ -23,8 +23,6 @@ GEM
       jekyll (~> 3.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
-    jekyll-tagging (1.1.0)
-      nuggets
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kramdown (1.15.0)
@@ -33,7 +31,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    nuggets (1.5.0)
     pathutil (0.16.0)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.0)
@@ -55,8 +52,7 @@ DEPENDENCIES
   jekyll (~> 3.6.2)
   jekyll-feed (~> 0.6)
   jekyll-paginate-v2
-  jekyll-tagging (~> 1.0, >= 1.0.1)
   tzinfo-data
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -63,6 +63,9 @@ autopages:
       - 'autopage_tags.html'
     title: ':tag' # :tag is replaced by the tag name
     permalink: '/tag/:tag'
+    slugify:
+      mode: pretty
+      cased: true
 
   categories:
     enabled: false 

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -27,11 +27,10 @@ github_username:  andy5995
 
 # Build settings
 markdown: kramdown
-# theme: minima
+
 plugins:
   - jekyll-feed
   - jekyll-paginate-v2
-  - jekyll/tagging
 
 tag_page_layout: tag
 tag_page_dir: tag
@@ -50,6 +49,28 @@ pagination:
   trail:
     before: 2 # The number of links before the current page
     after: 2  # The number of links after the current page
+
+############################################################
+# Site configuration for the Auto-Pages feature
+# The values here represent the defaults if nothing is set
+autopages:
+  # Site-wide kill switch, disable here and it doesn't run at all 
+  enabled: true
+
+  tags:
+    enabled: true
+    layouts: 
+      - 'autopage_tags.html'
+    title: ':tag' # :tag is replaced by the tag name
+    permalink: '/tag/:tag'
+
+  categories:
+    enabled: false 
+
+  collections:
+    enabled: false
+# Auto-pages config END
+############################################################
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/jekyll/_includes/post_display.html
+++ b/jekyll/_includes/post_display.html
@@ -4,7 +4,7 @@
 	</div>
 	<div>
 		{% for tag in post.tags %}
-		<a class="btn btn-primary" href="{{ site.url }}/{{ site.tag_page_dir }}/{{ tag | slugify: 'pretty' }}/">{{ tag }}</a>
+		<a class="btn btn-primary" href="{{ site.url }}/{{ site.tag_page_dir }}/{{ tag | downcase }}/">{{ tag }}</a>
 		{% endfor %}
 	</div>
 </div>

--- a/jekyll/_includes/post_display.html
+++ b/jekyll/_includes/post_display.html
@@ -4,7 +4,7 @@
 	</div>
 	<div>
 		{% for tag in post.tags %}
-		<a class="btn btn-primary" href="{{ site.url }}/{{ site.tag_page_dir }}/{{ tag | downcase }}/">{{ tag }}</a>
+		<a class="btn btn-primary" href="{{ site.url }}/{{ site.tag_page_dir }}/{{ tag | slugify: 'pretty' | downcase }}/">{{ tag }}</a>
 		{% endfor %}
 	</div>
 </div>

--- a/jekyll/_layouts/autopage_tags.html
+++ b/jekyll/_layouts/autopage_tags.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<h2 align="center">TEST post tags: {{ page.tag }}</h2>
+<h2 align="center">post tags: {% if page.autopages %}{{page.autopages.display_name}}{% endif %}</h2>
 <div class="container">
   <div class="text-center">
     {% include search_box.html %}

--- a/jekyll/_layouts/autopage_tags.html
+++ b/jekyll/_layouts/autopage_tags.html
@@ -1,47 +1,12 @@
 ---
 layout: default
 ---
-<!-- Just some nice to have styles for the pager buttons -->
-<style>
-  ul.pager { text-align: center; list-style: none; }
-  ul.pager li {display: inline;border: 1px solid black; padding: 10px; margin: 5px;}
-</style>
-<div class="home">
-  <h1 class="page-heading">AutoPage for Tag <b>{% if page.autopages %}{{page.autopages.display_name}}{% endif %}</b> Page {{page.pagination_info.curr_page}} of {{page.pagination_info.total_pages}}</h1>
-  This page is automagically created and paginated for each tag available in the posts on this site
-  {{ content | markdownify }}
-  <ul class="post-list">
-
-    <!--
-        Here is the main paginator logic called.
-        All calls to site.posts should be replaced by paginator.posts
-    -->
+<h2 align="center">TEST post tags: {{ page.tag }}</h2>
+<div class="container">
+  <div class="text-center">
+    {% include search_box.html %}
     {% for post in paginator.posts %}
-      <li>
-        <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}{% if post.book.rank %} | Rank: {{ post.book.rank }}{% endif %}{% if post.collection %} | {{ post.collection }}{% endif %}{% if post.tags %}<br>Tags: {{ post.tags }}{% endif %}</span>
-        <h2>
-          <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-        </h2>
-      </li>
+        {% include post_display.html %}
     {% endfor %}
-  </ul>
-
-  <!--
-    Showing buttons to move to the next and to the previous list of posts (pager buttons).
-  -->
-  {% if paginator.total_pages > 1 %}
-  <ul class="pager">
-    {% if paginator.previous_page %}
-    <li class="previous">
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
-    </li>
-    {% endif %}
-    {% if paginator.next_page %}
-    <li class="next">
-      <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older Posts &rarr;</a>
-    </li>
-    {% endif %}
-  </ul>
-  {% endif %}
-  <p class="rss-subscribe">subscribe <a href="/feed.xml">via RSS</a></p>
+  </div>
 </div>

--- a/jekyll/_plugins/ext.rb
+++ b/jekyll/_plugins/ext.rb
@@ -1,1 +1,0 @@
-require 'jekyll/tagging'


### PR DESCRIPTION
I've figured out how to use the autopages feature of jekyll-paginate-v2 so I was able to completely remove the jekyll-tagging plugin.

I've fixed the issues in issue #73, with the settings in autopages.

We should be able to implement pagination in the tag pages now as well so this is relevant to issue #31 