### PR TITLE
Update tag layout for pagination trail, Closes #31

### DIFF
--- a/jekyll/_layouts/autopage_tags.html
+++ b/jekyll/_layouts/autopage_tags.html
@@ -5,8 +5,10 @@ layout: default
 <div class="container">
   <div class="text-center">
     {% include search_box.html %}
+    {% include pagination_trail.html %}
     {% for post in paginator.posts %}
         {% include post_display.html %}
     {% endfor %}
+    {% include pagination_trail.html %}
   </div>
 </div>


### PR DESCRIPTION
The change I had made in PR #129 actually turned on pagination for tagging but the pagination trail wasn't being displayed,

It is now displayed just like the other pages so this will close #31 

For an example checkout the `doctors` tag as it has more the 15 records and therefore will be paginated.