### PR TITLE
Tag Languages

### DIFF
--- a/jekyll/_includes/post_display.html
+++ b/jekyll/_includes/post_display.html
@@ -1,4 +1,4 @@
-<div class="panel">
+<div class="panel" lang-id="{{ post.categories[0] }}">
 	<div>
 		<a class="panel-title" href="{{ post.href }}">{{ post.title }}</a>
 	</div>

--- a/jekyll/assets/js/mhwkb-scripts.js
+++ b/jekyll/assets/js/mhwkb-scripts.js
@@ -47,18 +47,25 @@ function getLanguageDataAvailable() {
 
 // USER TO SET DATA-LANGUGE ATTRIBUTE FOR #languageSelector element
 function getCurrentLanguageFromURL() {
-   var url = document.location.href;
-   var categoryString = "/category/"
+  var url = document.location.href;
+  var categoryString = "/category/";
+  var tagString = "/tag/";
 
-   if (url.includes(categoryString)) {
-      var catString = categoryString + url.substr(url.indexOf(categoryString) + categoryString.length, categoryString.length);
-      catString = catString.substr(0, catString.length - 1);    
-      var langData = languageDropDownDataList.find(x => x.url == catString);
-      return langData.lang;
-   }
-   else {
-      return '00_00';
-   }
+  if (url.includes(categoryString)) {
+    var catString = categoryString + url.substr(url.indexOf(categoryString) + categoryString.length, categoryString.length);
+    catString = catString.substr(0, catString.length - 1);    
+    var langData = languageDropDownDataList.find(x => x.url == catString);
+    return langData.lang;
+  }
+  else if (url.includes(tagString)){
+    var langID = $(".panel").first().attr("lang-id");
+    var urlString = categoryString + langID;
+    var langData = languageDropDownDataList.find(x => x.url == urlString);
+    return langData.lang;
+  }
+  else {
+    return '00_00';
+  }
 }
 
 // FOR LANGUAGE DROPDOWN CHANGE DETECTION


### PR DESCRIPTION
This will make it so each post panel has a language associated to it in the `lang-id` attribute which can be used to tell what language the tag is associated to.

I created a similar function to PR #128 which will get this lang-id attribute and determine the languge and set it in the language selector.  This is really just a work around but it allows for the tag pages to have the proper language selected.

This may solve the issue for #112 