### PR TITLE
Added alphabetical sorting of posts in EN category

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,4 +23,5 @@ GitHub's automated list: (former repo) [graphs/contributors](https://github.com/
 | [khipukamayuq](https://github.com/khipukamayuq) |  |
 | [Martijn de Boer](https://github.com/sexybiggetje) |  |
 | [Forrest Stone](https://github.com/SinGarTheGoat/) |  |
+| [dreamingblackcat](https://github.com/dreamingblackcat/) | HTML, CSS, Jekyll |
 | | |

--- a/_includes/post_sorting_types.html
+++ b/_includes/post_sorting_types.html
@@ -1,0 +1,1 @@
+<p>Sorting: <a href="/category/EN/alphabetical">Alphabetical</a> || <a href="/category/EN">By Date</a></p>

--- a/_layouts/category_index_alphabetical.html
+++ b/_layouts/category_index_alphabetical.html
@@ -7,7 +7,7 @@ layout: default
     {% include search_box.html %}
     {% include pagination_trail.html %}
     {% for post in paginator.posts %}
-        {% include post_display.html %}
+    {% include post_display.html %}
     {% endfor %}
     {% include pagination_trail.html %}
   </div>

--- a/category/EN_alphabetical.html
+++ b/category/EN_alphabetical.html
@@ -1,0 +1,12 @@
+---
+layout: category_index
+title: English
+permalink: /category/EN/alphabetical
+category: EN
+pagination:
+  enabled: true
+  category: EN
+  permalink: /:num/
+  sort_field: 'title'
+  sort_reverse: false
+---


### PR DESCRIPTION
Hi I've come across issue #33  and got curious about how it could be implemented. I did some research and found this example [https://github.com/sverrirs/jekyll-paginate-v2/tree/master/examples/02-category](https://github.com/sverrirs/jekyll-paginate-v2/tree/master/examples/02-category) in jeyll-paginate-v2 repo.
So, I tried to implement it for EN category and looks like it works.

So, my approach here is to use another category page for EN namely EN_alphabetcial which is identical to EN but with different sorting of posts. Then I added a simple partial to switch between those two differnt pages. It's at `includes/post_sorting_types.html` and it simple provided two links for switching between normal and alphabetical sorting.

The approach used the same strategy that you first described in the issue. I am new to this codebase and please do guide me along for any changes you would like to do.